### PR TITLE
Replace spaces to - signs for correct url creation

### DIFF
--- a/app/routes/($lang).modules.tsx
+++ b/app/routes/($lang).modules.tsx
@@ -49,7 +49,7 @@ export default function Product() {
                       <td >{module.company.name}</td>
                       {
                         module.external_url ? <td ><Link className="underline" target="_blank" to={module.external_url}>{module.name}<IconLink className="inline-block" /></Link></td> :
-                          module.is_active_product ? <td ><Link className="underline" to={'/products/' + module.name.toLowerCase().replace(/\//g, '')}>{module.name}</Link></td> : <td >{module.name}</td>
+                          module.is_active_product ? <td ><Link className="underline" to={'/products/' + module.name.toLowerCase().replace(/\//g, '').replace(/\s/g, '-')}>{module.name}</Link></td> : <td >{module.name}</td>
                       }
                       <td className={module.is_active_product ? 'text-green-500' : 'text-yellow-500'}>{module.is_active_product ? 'Active' : 'Legacy'}</td>
                       <td >{module.hp}HP</td>


### PR DESCRIPTION
if theres a module.name with spaces they will be used to create broken links like:
`https://lzxindustries.net/products/castle 000 adc`
One solution to avoid this could be the use of another replace function which converts all empty spaces to - signs, which produces legit url paths like:
`https://lzxindustries.net/products/castle-000-adc`