### PR TITLE
Add vary header

### DIFF
--- a/app/routes/($lang).products.$productHandle.tsx
+++ b/app/routes/($lang).products.$productHandle.tsx
@@ -123,7 +123,8 @@ export async function loader({ params, request, context }: LoaderArgs) {
     {
       headers: {
         'Cache-Control': CACHE_LONG,
-        'Oxygen-Cache-Control': 'public, max-age=3600, stale-while-revalidate=600'
+        'Oxygen-Cache-Control': 'public, max-age=3600, stale-while-revalidate=600',
+        'Vary': 'Accept-Language, Accept-Encoding'
       },
     },
   );


### PR DESCRIPTION
This PR adds a `Vary` header to product route requests to meet [full-page caching criteria](https://shopify.dev/docs/storefronts/headless/hydrogen/caching/full-page-cache#caching-criteria). 