### PR TITLE
 Update stale-while-revalidate for full-page caching to 23 hours

### DIFF
--- a/app/routes/($lang).products.$productHandle.tsx
+++ b/app/routes/($lang).products.$productHandle.tsx
@@ -123,7 +123,7 @@ export async function loader({ params, request, context }: LoaderArgs) {
     {
       headers: {
         'Cache-Control': CACHE_LONG,
-        'Oxygen-Cache-Control': 'public, max-age=3600, stale-while-revalidate=600',
+        'Oxygen-Cache-Control': 'public, max-age=3600, stale-while-revalidate=82800',
         'Vary': 'Accept-Language, Accept-Encoding'
       },
     },

--- a/app/routes/($lang).products.$productHandle.tsx
+++ b/app/routes/($lang).products.$productHandle.tsx
@@ -122,7 +122,7 @@ export async function loader({ params, request, context }: LoaderArgs) {
     },
     {
       headers: {
-        'Cache-Control': CACHE_LONG,
+        'Cache-Control': CACHE_SHORT,
         'Oxygen-Cache-Control': 'public, max-age=3600, stale-while-revalidate=82800',
         'Vary': 'Accept-Language, Accept-Encoding'
       },


### PR DESCRIPTION
 Updates stale-while-revalidate for full-page caching to 23 hours, and reduces the browser caching window.