### PR TITLE
Move caching headers to server response

### DIFF
--- a/app/routes/($lang).products.$productHandle.tsx
+++ b/app/routes/($lang).products.$productHandle.tsx
@@ -48,8 +48,6 @@ import { ModuleDetails } from '~/components/ModuleDetails';
 import { ModuleView } from '~/views/module';
 import { getModuleDetails } from '~/controllers/get_module_details';
 import { ModuleGallery } from '~/components/ModuleGallery';
-import { routeHeaders, CACHE_SHORT } from '~/data/cache';
-export const headers = routeHeaders;
 
 export async function loader({ params, request, context }: LoaderArgs) {
   const { productHandle } = params;
@@ -119,14 +117,7 @@ export async function loader({ params, request, context }: LoaderArgs) {
         totalValue: parseFloat(selectedVariant.price.amount),
       },
       seo,
-    },
-    {
-      headers: {
-        'Cache-Control': CACHE_SHORT,
-        'Oxygen-Cache-Control': 'public, max-age=3600, stale-while-revalidate=82800',
-        'Vary': 'Accept-Language, Accept-Encoding'
-      },
-    },
+    }
   );
 }
 

--- a/server.ts
+++ b/server.ts
@@ -7,6 +7,7 @@ import {
 import {createStorefrontClient, storefrontRedirect} from '@shopify/hydrogen';
 import {HydrogenSession} from '~/lib/session.server';
 import {getLocaleFromRequest} from '~/lib/utils';
+import { CACHE_SHORT } from '~/data/cache';
 
 /**
  * Export a fetch handler in module format.
@@ -72,6 +73,10 @@ export default {
          */
         return storefrontRedirect({request, response, storefront});
       }
+
+      response.headers.set('Cache-Control', CACHE_SHORT);
+      response.headers.set('Oxygen-Cache-Control', 'public, max-age=3600, stale-while-revalidate=82800');
+      response.headers.set('Vary', 'Accept-Language, Accept-Encoding'); 
 
       return response;
     } catch (error) {


### PR DESCRIPTION
Moves caching headers to server response, since full-page caching may not work if they are only set in the request.