### PR TITLE
Remove language from vary header

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -76,7 +76,7 @@ export default {
 
       response.headers.set('Cache-Control', CACHE_SHORT);
       response.headers.set('Oxygen-Cache-Control', 'public, max-age=3600, stale-while-revalidate=82800');
-      response.headers.set('Vary', 'Accept-Language, Accept-Encoding'); 
+      response.headers.set('Vary', 'Accept-Encoding'); 
 
       return response;
     } catch (error) {


### PR DESCRIPTION
Removes language segmentation for full-page caching. 

This should be added back once the site supports additional languages.