### PR TITLE
Increase full-page caching stale-while-revalidate value to 3 days

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -75,7 +75,7 @@ export default {
       }
 
       response.headers.set('Cache-Control', CACHE_SHORT);
-      response.headers.set('Oxygen-Cache-Control', 'public, max-age=3600, stale-while-revalidate=82800');
+      response.headers.set('Oxygen-Cache-Control', 'public, max-age=3600, stale-while-revalidate=259200');
       response.headers.set('Vary', 'Accept-Encoding'); 
 
       return response;


### PR DESCRIPTION
Increases the `stale-while-revalidate` value for full-page caching to 3 days.