### PR TITLE
Migrate from oxygenctl-action to Hydrogen CLI

### DIFF
--- a/.github/workflows/oxygen-deployment-950295.yml
+++ b/.github/workflows/oxygen-deployment-950295.yml
@@ -2,54 +2,37 @@
 #! oxygen_storefront_id: 950295
 
 name: Storefront 950295
-on: [push]
-
+on:
+- push
 permissions:
   contents: read
   deployments: write
-
 jobs:
   deploy:
     name: Deploy to Oxygen
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - name: Setup node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+        check-latest: true
+    - name: Get yarn cache directory
+      id: yarn-cache-dir-path
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+    - uses: actions/cache@v3
+      with:
+        path: "${{ steps.yarn-cache-dir-path.outputs.dir }}"
+        key: "${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}"
+        restore-keys: "${{ runner.os }}-yarn-\n"
+    - name: Install dependencies
+      id: install-dependencies
+      run: yarn
+    - name: Build and Publish to Oxygen
+      id: deploy
+      run: npx shopify hydrogen deploy --build-command "yarn build"
+      env:
+        SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN: "${{ secrets.OXYGEN_DEPLOYMENT_TOKEN_950295 }}"
 
-      - name: Setup node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-          check-latest: true
-
-      - name: Get yarn cache directory
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install dependencies
-        id: 'install-dependencies'
-        run: yarn
-
-      - name: Build and Publish to Oxygen
-        id: deploy
-        uses: shopify/oxygenctl-action@v4
-        with:
-          oxygen_deployment_token: ${{ secrets.OXYGEN_DEPLOYMENT_TOKEN_950295 }}
-          build_command: "HYDROGEN_ASSET_BASE_URL=$OXYGEN_ASSET_BASE_URL yarn build"
-
-      # Create GitHub Deployment
-      - name: Create GitHub Deployment
-        uses: shopify/github-deployment-action@v1
-        if: always()
-        with:
-          token: ${{ github.token }}
-          environment: 'preview'
-          preview_url: ${{ steps.deploy.outputs.url }}
-          description: ${{ github.event.head_commit.message }}


### PR DESCRIPTION
Tries again to apply Shopify bot [recommendation](https://github.com/garytyler/lzxfrontend/commit/018233dd07574ce7c93b5ceb5f1281a414dfdb1d) to update deployment action.

If deployment fails with this merged, we should revert it.