### PR TITLE
Do not set full-page cache response headers on cart page

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -74,11 +74,13 @@ export default {
       }
 
       response.headers.set('Cache-Control', CACHE_SHORT);
-      response.headers.set(
-        'Oxygen-Cache-Control',
-        'public, max-age=3600, stale-while-revalidate=259200',
-      );
-      response.headers.set('Vary', 'Accept-Encoding');
+      if (new URL(request.url).pathname.endsWith('/cart')) {
+        response.headers.set(
+          'Oxygen-Cache-Control',
+          'public, max-age=3600, stale-while-revalidate=259200',
+        );
+        response.headers.set('Vary', 'Accept-Encoding');
+      }
 
       return response;
     } catch (error) {

--- a/server.ts
+++ b/server.ts
@@ -73,8 +73,8 @@ export default {
         return storefrontRedirect({request, response, storefront});
       }
 
-      response.headers.set('Cache-Control', CACHE_SHORT);
-      if (new URL(request.url).pathname.endsWith('/cart')) {
+      if (!new URL(request.url).pathname.endsWith('/cart')) {
+        response.headers.set('Cache-Control', CACHE_SHORT);
         response.headers.set(
           'Oxygen-Cache-Control',
           'public, max-age=3600, stale-while-revalidate=259200',


### PR DESCRIPTION
We shouldn't cache the cart page, so this PR excludes the cart page from full-page caching.