### PR TITLE
Update yarn build commands in deploy action

### DIFF
--- a/.github/workflows/oxygen-deployment-950295.yml
+++ b/.github/workflows/oxygen-deployment-950295.yml
@@ -29,7 +29,7 @@ jobs:
         run: yarn --version
       - name: Get yarn cache directory
         id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
           path: '${{ steps.yarn-cache-dir-path.outputs.dir }}'
@@ -40,6 +40,6 @@ jobs:
         run: yarn
       - name: Build and Publish to Oxygen
         id: deploy
-        run: npx shopify hydrogen deploy --build-command "yarn build"
+        run: yarn run shopify hydrogen deploy --build-command "yarn run build"
         env:
           SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN: '${{ secrets.OXYGEN_DEPLOYMENT_TOKEN_950295 }}'


### PR DESCRIPTION
- Replace `yarn cache dir` with `yarn config get cacheFolder`
- Replace `npx shopify hydrogen deploy --build-command "yarn build"` with `yarn run shopify hydrogen deploy --build-command "yarn run build"`
