### PR TITLE
Fix conflict in graphql policies query naming

### DIFF
--- a/app/routes/($lang).policies.$policyHandle.tsx
+++ b/app/routes/($lang).policies.$policyHandle.tsx
@@ -100,7 +100,7 @@ const POLICY_CONTENT_QUERY = `#graphql
     url
   }
 
-  query PoliciesQuery(
+  query PolicyContentsQuery(
     $language: LanguageCode
     $privacyPolicy: Boolean!
     $shippingPolicy: Boolean!


### PR DESCRIPTION
Fix conflict in graphql policies query naming by renaming `PoliciesQuery` to `PolicyContentsQuery`.