### PR TITLE
Set a gray hover on country selector menu items

### DIFF
--- a/app/components/CountrySelector.tsx
+++ b/app/components/CountrySelector.tsx
@@ -116,7 +116,7 @@ function Country({
         className={clsx([
           'text-contrast dark:text-primary border-none',
           'bg-primary dark:bg-contrast w-full rounded-none p-2 transition flex justify-start',
-          'items-center text-left cursor-pointer py-2 px-4',
+          'items-center text-left cursor-pointer py-2 px-4 hover:bg-gray-300',
         ])}
         type="submit"
         variant="primary"


### PR DESCRIPTION
The default hover on the country selector menu was black. This PR sets it to gray.