### PR TITLE
Source product gallery media from Shopify Storefront API

### DIFF
--- a/app/components/ModuleDetails.tsx
+++ b/app/components/ModuleDetails.tsx
@@ -1,8 +1,9 @@
+import type {Product} from '@shopify/hydrogen/dist/storefront-api-types';
 import React, {useState, useEffect} from 'react';
 import {TbRectangleFilled} from 'react-icons/tb';
 import {ModuleLegendPanel} from './ModuleLegendPanel';
+import ProductMediaGallery from './ProductMediaGallery';
 import type {ModuleView} from '~/views/module';
-import ImageCroppedByTransparency from './ImageCroppedByTransparency';
 
 interface MediaItem {
   name: string;
@@ -13,9 +14,11 @@ interface MediaItem {
 export function ModuleDetails({
   children,
   moduleData,
+  product,
 }: {
   children?: React.ReactNode;
   moduleData: ModuleView;
+  product: Product;
 }) {
   const [activeRefDes, setActiveRefDes] = useState('');
   let hasMainFeatures = false;
@@ -43,12 +46,6 @@ export function ModuleDetails({
     }),
   );
 
-  const [currentSlide, setCurrentSlide] = useState(0);
-
-  const nextSlide = () => setCurrentSlide((prev) => (prev + 1) % media.length);
-  const prevSlide = () =>
-    setCurrentSlide((prev) => (prev - 1 + media.length) % media.length);
-  const [screenWidth, setScreenWidth] = useState<number>(0);
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const handleResize = () => setScreenWidth(window.innerWidth);
@@ -61,95 +58,10 @@ export function ModuleDetails({
       key="ModuleDetails"
       className="flex flex-wrap flex-row justify-center p-0 m-0"
     >
-      <div className="w-full lg:w-1/2 card-image">
-        <div className="flex-row">
-          <div className="flex items-center relative aspect-square p-1 lg:p-2">
-            <button
-              onClick={prevSlide}
-              className="mb-0 p-0 text-black rounded-full bg-white any-hover:hover:bg-black any-hover:hover:text-white border border-gray-500 transition-colors duration-200 md:p-1 lg:p-1 m-0 lg:m-1"
-              aria-label="Next Slide"
-              style={{visibility: media.length <= 1 ? 'hidden' : 'visible'}}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-12 w-8"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={3}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M15 19l-7-7 7-7"
-                />
-              </svg>
-            </button>
-            <div className="flex justify-center w-full h-full p-1 lg:p-2 overflow-hidden ">
-              {/* <div className="flex justify-center w-full h-[400px] sm:h-[500px] md:h-[800px] lg:h-[800px] xl:h-[1100px]"> */}
-              {media[currentSlide].type === 'image' ? (
-                <div className="object-contain">
-                  <ImageCroppedByTransparency
-                    src={media[currentSlide].src}
-                    alt="Cropped Module Image"
-                  />
-                </div>
-              ) : (
-                <div className="w-full ">
-                  <div className="relative inset-y-[25%]">
-                    <iframe
-                      className="aspect-video w-full "
-                      src={media[currentSlide].src}
-                      title="Video Slide"
-                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen"
-                    />
-                  </div>
-                </div>
-              )}
-            </div>
-            <button
-              onClick={nextSlide}
-              className="mb-0 p-0 text-black rounded-full bg-white any-hover:hover:bg-black any-hover:hover:text-white border border-gray-500 transition-colors duration-200 md:p-1 lg:p-1 m-0 lg:m-1"
-              aria-label="Next Slide"
-              style={{visibility: media.length <= 1 ? 'hidden' : 'visible'}}
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-12 w-8"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={3}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M9 5l7 7-7 7"
-                />
-              </svg>
-            </button>
-          </div>
-          {media.length > 1 && (
-            <div
-              className="flex justify-center items-center mb-2 mt-0 pt-0"
-              style={{visibility: media.length <= 1 ? 'hidden' : 'visible'}}
-            >
-              <div className="inline-flex justify-center items-center bg-white rounded-full any-hover:hover:bg-gray-100 border border-gray-500 transition-colors duration-200 p-2 mx-auto">
-                {media.map((_, index) => (
-                  <button
-                    key={media.length > 1 ? media[index].name : ''}
-                    onClick={() => setCurrentSlide(index)}
-                    className={`w-3 h-3 mx-1 rounded-full any-hover:hover:bg-black ${
-                      index === currentSlide ? 'bg-black' : 'bg-gray-300'
-                    }`}
-                    aria-label={`Slide ${index + 1}`}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
+      <ProductMediaGallery
+        product={product}
+        moduleData={moduleData}
+      ></ProductMediaGallery>
       <div className="basis-[100%] md:basis-1/2 md:h-screen hiddenScroll md:overflow-y-scroll">
         <div className="flex flex-wrap flex-row px-8">
           <div className="basis-[100%] md:basis-1/2 pb-8">

--- a/app/components/ProductMediaGallery.tsx
+++ b/app/components/ProductMediaGallery.tsx
@@ -1,0 +1,195 @@
+import type {
+  Product,
+  Media,
+  ExternalVideo,
+  MediaImage,
+} from '@shopify/hydrogen/storefront-api-types';
+import React, {useState} from 'react';
+import ImageCroppedByTransparency from './ImageCroppedByTransparency';
+
+enum MediaGalleryItemType {
+  IMAGE = 'IMAGE',
+  VIDEO = 'VIDEO',
+}
+
+interface MediaGalleryItem {
+  name: string;
+  src: string;
+  type: MediaGalleryItemType;
+}
+
+interface ProductMediaGalleryProps {
+  product: Product;
+  moduleData: any;
+}
+
+function getLastPathSegment(url: string): string | null {
+  try {
+    const parsedUrl = new URL(url);
+    const segments = parsedUrl.pathname
+      .split('/')
+      .filter((segment) => segment.length > 0);
+    return segments.length > 0 ? segments[segments.length - 1] : null;
+  } catch (error) {
+    console.error('Invalid URL:', error);
+    return null;
+  }
+}
+
+const ProductMediaGallery: React.FC<ProductMediaGalleryProps> = ({
+  product,
+  moduleData,
+}) => {
+  const mediaGalleryItems: MediaGalleryItem[] = [];
+
+  const seenYoutubeIds = new Set<string>();
+  product.media.nodes.forEach((item: Media, index) => {
+    if (item.mediaContentType === 'IMAGE') {
+      const shopifyImage = item as MediaImage;
+      if (!shopifyImage.image) return;
+      mediaGalleryItems.push({
+        name: shopifyImage.image.altText || `${moduleData.name} image`,
+        src: shopifyImage.image.url,
+        type: MediaGalleryItemType.IMAGE,
+      } as MediaGalleryItem);
+    } else if (item.mediaContentType === 'EXTERNAL_VIDEO') {
+      const shopifyExternalVideo = item as ExternalVideo;
+      const youtubeId = getLastPathSegment(shopifyExternalVideo.embedUrl);
+      if (!youtubeId) return;
+      seenYoutubeIds.add(youtubeId);
+      mediaGalleryItems.push({
+        name: `${moduleData.name} video (${shopifyExternalVideo.host})`,
+        src: shopifyExternalVideo.embedUrl,
+        type: MediaGalleryItemType.VIDEO,
+      } as MediaGalleryItem);
+    }
+  });
+
+  moduleData.videos.forEach((video: any) => {
+    if (seenYoutubeIds.has(video.youtube)) return;
+    mediaGalleryItems.push({
+      name: video.name,
+      src: `https://www.youtube.com/embed/${video.youtube}`,
+      type: MediaGalleryItemType.VIDEO,
+    } as MediaGalleryItem);
+  });
+
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const nextSlide = () =>
+    setCurrentSlide((prev) => (prev + 1) % mediaGalleryItems.length);
+  const prevSlide = () =>
+    setCurrentSlide(
+      (prev) =>
+        (prev - 1 + mediaGalleryItems.length) % mediaGalleryItems.length,
+    );
+
+  return (
+    <div className="w-full lg:w-1/2 card-image">
+      <div className="flex-row">
+        <div className="flex items-center relative aspect-square p-1 lg:p-2">
+          <button
+            onClick={prevSlide}
+            className="mb-0 p-0 text-black rounded-full bg-white any-hover:hover:bg-black any-hover:hover:text-white border border-gray-500 transition-colors duration-200 md:p-1 lg:p-1 m-0 lg:m-1"
+            aria-label="Previous Slide"
+            style={{
+              visibility: mediaGalleryItems.length <= 1 ? 'hidden' : 'visible',
+            }}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-12 w-8"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={3}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+          </button>
+          <div className="flex justify-center w-full h-full p-1 lg:p-2 overflow-hidden ">
+            {mediaGalleryItems[currentSlide].type ===
+            MediaGalleryItemType.IMAGE ? (
+              <div className="object-contain">
+                <ImageCroppedByTransparency
+                  src={mediaGalleryItems[currentSlide].src}
+                  alt={mediaGalleryItems[currentSlide].name}
+                />
+                {/* <img
+                  className="w-full h-full object-contain"
+                  src={mediaGalleryItems[currentSlide].src}
+                  alt={mediaGalleryItems[currentSlide].name}
+                /> */}
+              </div>
+            ) : mediaGalleryItems[currentSlide].type ===
+              MediaGalleryItemType.VIDEO ? (
+              <div className="w-full ">
+                <div className="relative inset-y-[25%]">
+                  <iframe
+                    className="aspect-video w-full "
+                    src={mediaGalleryItems[currentSlide].src}
+                    title={mediaGalleryItems[currentSlide].name}
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen"
+                  />
+                </div>
+              </div>
+            ) : null}
+          </div>
+          <button
+            onClick={nextSlide}
+            className="mb-0 p-0 text-black rounded-full bg-white any-hover:hover:bg-black any-hover:hover:text-white border border-gray-500 transition-colors duration-200 md:p-1 lg:p-1 m-0 lg:m-1"
+            aria-label="Next Slide"
+            style={{
+              visibility: mediaGalleryItems.length <= 1 ? 'hidden' : 'visible',
+            }}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-12 w-8"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={3}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+          </button>
+        </div>
+        {mediaGalleryItems.length > 1 && (
+          <div
+            className="flex justify-center items-center mb-2 mt-0 pt-0"
+            style={{
+              visibility: mediaGalleryItems.length <= 1 ? 'hidden' : 'visible',
+            }}
+          >
+            <div className="inline-flex justify-center items-center bg-white rounded-full any-hover:hover:bg-gray-100 border border-gray-500 transition-colors duration-200 p-2 mx-auto">
+              {mediaGalleryItems.map((_, index) => (
+                <button
+                  key={
+                    mediaGalleryItems.length > 1
+                      ? mediaGalleryItems[index].name
+                      : ''
+                  }
+                  onClick={() => setCurrentSlide(index)}
+                  className={`w-3 h-3 mx-1 rounded-full any-hover:hover:bg-black ${
+                    index === currentSlide ? 'bg-black' : 'bg-gray-300'
+                  }`}
+                  aria-label={`Slide ${index + 1}`}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ProductMediaGallery;

--- a/app/components/ProductMediaGallery.tsx
+++ b/app/components/ProductMediaGallery.tsx
@@ -20,10 +20,59 @@ interface MediaGalleryItem {
 
 interface ProductMediaGalleryProps {
   product: Product;
-  moduleData: any;
+  moduleData: ModuleData;
 }
 
-function getLastPathSegment(url: string): string | null {
+interface ModuleData {
+  name: string;
+  videos: {youtube: string; name: string}[];
+}
+
+const getGalleryMedia = (
+  product: Product,
+  moduleData: {
+    name: string;
+    videos: {youtube: string; name: string}[];
+  },
+): MediaGalleryItem[] => {
+  const items: MediaGalleryItem[] = [];
+  const seenYoutubeIds = new Set<string>();
+
+  product.media.nodes.forEach((item: Media, index) => {
+    if (item.mediaContentType === 'IMAGE') {
+      const shopifyImage = item as MediaImage;
+      if (!shopifyImage.image) return;
+      items.push({
+        name: shopifyImage.image.altText || `${moduleData.name} image`,
+        src: shopifyImage.image.url,
+        type: MediaGalleryItemType.IMAGE,
+      } as MediaGalleryItem);
+    } else if (item.mediaContentType === 'EXTERNAL_VIDEO') {
+      const shopifyExternalVideo = item as ExternalVideo;
+      const youtubeId = getLastPathSegment(shopifyExternalVideo.embedUrl);
+      if (!youtubeId) return;
+      seenYoutubeIds.add(youtubeId);
+      items.push({
+        name: `${moduleData.name} video (${shopifyExternalVideo.host})`,
+        src: shopifyExternalVideo.embedUrl,
+        type: MediaGalleryItemType.VIDEO,
+      } as MediaGalleryItem);
+    }
+  });
+
+  moduleData.videos.forEach((video: any) => {
+    if (seenYoutubeIds.has(video.youtube)) return;
+    items.push({
+      name: video.name,
+      src: `https://www.youtube.com/embed/${video.youtube}`,
+      type: MediaGalleryItemType.VIDEO,
+    } as MediaGalleryItem);
+  });
+
+  return items;
+};
+
+const getLastPathSegment = (url: string): string | null => {
   try {
     const parsedUrl = new URL(url);
     const segments = parsedUrl.pathname
@@ -34,11 +83,11 @@ function getLastPathSegment(url: string): string | null {
     console.error('Invalid URL:', error);
     return null;
   }
-}
+};
 
 const croppedCache: Record<string, string> = {};
 
-function cropImageWithCache(src: string): Promise<string> {
+const cropImageWithCache = (src: string): Promise<string> => {
   if (croppedCache[src]) {
     return Promise.resolve(croppedCache[src]);
   }
@@ -46,58 +95,20 @@ function cropImageWithCache(src: string): Promise<string> {
     croppedCache[src] = cropped;
     return cropped;
   });
-}
+};
 
 const ProductMediaGallery: React.FC<ProductMediaGalleryProps> = ({
   product,
   moduleData,
 }) => {
-  const mediaGalleryItems: MediaGalleryItem[] = useMemo(() => {
-    const items: MediaGalleryItem[] = [];
-    const seenYoutubeIds = new Set<string>();
-
-    product.media.nodes.forEach((item: Media, index) => {
-      if (item.mediaContentType === 'IMAGE') {
-        const shopifyImage = item as MediaImage;
-        if (!shopifyImage.image) return;
-        items.push({
-          name: shopifyImage.image.altText || `${moduleData.name} image`,
-          src: shopifyImage.image.url,
-          type: MediaGalleryItemType.IMAGE,
-        } as MediaGalleryItem);
-      } else if (item.mediaContentType === 'EXTERNAL_VIDEO') {
-        const shopifyExternalVideo = item as ExternalVideo;
-        const youtubeId = getLastPathSegment(shopifyExternalVideo.embedUrl);
-        if (!youtubeId) return;
-        seenYoutubeIds.add(youtubeId);
-        items.push({
-          name: `${moduleData.name} video (${shopifyExternalVideo.host})`,
-          src: shopifyExternalVideo.embedUrl,
-          type: MediaGalleryItemType.VIDEO,
-        } as MediaGalleryItem);
-      }
-    });
-
-    moduleData.videos.forEach((video: any) => {
-      if (seenYoutubeIds.has(video.youtube)) return;
-      items.push({
-        name: video.name,
-        src: `https://www.youtube.com/embed/${video.youtube}`,
-        type: MediaGalleryItemType.VIDEO,
-      } as MediaGalleryItem);
-    });
-
-    return items;
-  }, [product.media.nodes, moduleData]);
+  const media: MediaGalleryItem[] = useMemo(() => {
+    return getGalleryMedia(product, moduleData);
+  }, [product, moduleData]);
 
   const [currentSlide, setCurrentSlide] = useState(0);
-  const nextSlide = () =>
-    setCurrentSlide((prev) => (prev + 1) % mediaGalleryItems.length);
+  const nextSlide = () => setCurrentSlide((prev) => (prev + 1) % media.length);
   const prevSlide = () =>
-    setCurrentSlide(
-      (prev) =>
-        (prev - 1 + mediaGalleryItems.length) % mediaGalleryItems.length,
-    );
+    setCurrentSlide((prev) => (prev - 1 + media.length) % media.length);
 
   const [preCroppedImages, setPreCroppedImages] = useState<(string | null)[]>(
     [],
@@ -105,44 +116,27 @@ const ProductMediaGallery: React.FC<ProductMediaGalleryProps> = ({
 
   useEffect(() => {
     let isMounted = true;
-    setPreCroppedImages(Array(mediaGalleryItems.length).fill(null));
+    setPreCroppedImages(Array(media.length).fill(null));
 
     (async function processImages() {
-      // Crop item first
-      const currentItem = mediaGalleryItems[currentSlide];
-      if (currentItem && currentItem.type === MediaGalleryItemType.IMAGE) {
-        const croppedSrc = await cropImageWithCache(currentItem.src);
-        if (isMounted) {
-          setPreCroppedImages((prev) => {
-            const next = [...prev];
-            next[currentSlide] = croppedSrc;
-            return next;
-          });
-        }
-      }
-      // Crop other items
-      const otherIndices = mediaGalleryItems
-        .map((_, idx) => idx)
-        .filter((idx) => idx !== currentSlide);
-      for (const idx of otherIndices) {
-        const item = mediaGalleryItems[idx];
-        if (item.type === MediaGalleryItemType.IMAGE) {
-          const croppedSrc = await cropImageWithCache(item.src);
-          if (isMounted) {
-            setPreCroppedImages((prev) => {
-              const next = [...prev];
-              next[idx] = croppedSrc;
-              return next;
-            });
+      const croppedImages = await Promise.all(
+        media.map(async (item) => {
+          if (item.type === MediaGalleryItemType.IMAGE) {
+            return await cropImageWithCache(item.src);
           }
-        }
+          return null;
+        }),
+      );
+
+      if (isMounted) {
+        setPreCroppedImages(croppedImages);
       }
     })();
 
     return () => {
       isMounted = false;
     };
-  }, [mediaGalleryItems, currentSlide]);
+  }, [media, currentSlide]);
 
   return (
     <div className="w-full lg:w-1/2 card-image">
@@ -153,7 +147,7 @@ const ProductMediaGallery: React.FC<ProductMediaGalleryProps> = ({
             className="mb-0 p-0 text-black rounded-full bg-white any-hover:hover:bg-black any-hover:hover:text-white border border-gray-500 transition-colors duration-200 md:p-1 lg:p-1 m-0 lg:m-1"
             aria-label="Previous Slide"
             style={{
-              visibility: mediaGalleryItems.length <= 1 ? 'hidden' : 'visible',
+              visibility: media.length <= 1 ? 'hidden' : 'visible',
             }}
           >
             <svg
@@ -172,23 +166,21 @@ const ProductMediaGallery: React.FC<ProductMediaGalleryProps> = ({
             </svg>
           </button>
           <div className="flex justify-center w-full h-full p-1 lg:p-2 overflow-hidden ">
-            {mediaGalleryItems[currentSlide].type ===
-            MediaGalleryItemType.IMAGE ? (
+            {media[currentSlide].type === MediaGalleryItemType.IMAGE ? (
               preCroppedImages[currentSlide] ? (
                 <img
                   className="w-full h-full object-contain"
                   src={preCroppedImages[currentSlide]}
-                  alt={mediaGalleryItems[currentSlide].name}
+                  alt={media[currentSlide].name}
                 />
               ) : null
-            ) : mediaGalleryItems[currentSlide].type ===
-              MediaGalleryItemType.VIDEO ? (
+            ) : media[currentSlide].type === MediaGalleryItemType.VIDEO ? (
               <div className="w-full ">
                 <div className="relative inset-y-[25%]">
                   <iframe
                     className="aspect-video w-full "
-                    src={mediaGalleryItems[currentSlide].src}
-                    title={mediaGalleryItems[currentSlide].name}
+                    src={media[currentSlide].src}
+                    title={media[currentSlide].name}
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen"
                   />
                 </div>
@@ -200,7 +192,7 @@ const ProductMediaGallery: React.FC<ProductMediaGalleryProps> = ({
             className="mb-0 p-0 text-black rounded-full bg-white any-hover:hover:bg-black any-hover:hover:text-white border border-gray-500 transition-colors duration-200 md:p-1 lg:p-1 m-0 lg:m-1"
             aria-label="Next Slide"
             style={{
-              visibility: mediaGalleryItems.length <= 1 ? 'hidden' : 'visible',
+              visibility: media.length <= 1 ? 'hidden' : 'visible',
             }}
           >
             <svg
@@ -219,21 +211,17 @@ const ProductMediaGallery: React.FC<ProductMediaGalleryProps> = ({
             </svg>
           </button>
         </div>
-        {mediaGalleryItems.length > 1 && (
+        {media.length > 1 && (
           <div
             className="flex justify-center items-center mb-2 mt-0 pt-0"
             style={{
-              visibility: mediaGalleryItems.length <= 1 ? 'hidden' : 'visible',
+              visibility: media.length <= 1 ? 'hidden' : 'visible',
             }}
           >
             <div className="inline-flex justify-center items-center bg-white rounded-full any-hover:hover:bg-gray-100 border border-gray-500 transition-colors duration-200 p-2 mx-auto">
-              {mediaGalleryItems.map((_, index) => (
+              {media.map((_, index) => (
                 <button
-                  key={
-                    mediaGalleryItems.length > 1
-                      ? mediaGalleryItems[index].name
-                      : ''
-                  }
+                  key={media.length > 1 ? media[index].name : ''}
                   onClick={() => setCurrentSlide(index)}
                   className={`w-3 h-3 mx-1 rounded-full any-hover:hover:bg-black ${
                     index === currentSlide ? 'bg-black' : 'bg-gray-300'

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -317,7 +317,7 @@ export function getCartId(request: Request) {
   return cookies.cart ? `gid://shopify/Cart/${cookies.cart}` : undefined;
 }
 
-export function cropImageByTransparency(src: string): Promise<string> {
+export async function cropImageByTransparency(src: string): Promise<string> {
   return new Promise((resolve) => {
     const img = new Image();
     img.crossOrigin = 'Anonymous';

--- a/app/routes/($lang).products.$productHandle.tsx
+++ b/app/routes/($lang).products.$productHandle.tsx
@@ -116,7 +116,7 @@ export default function Product() {
   moduleData.description = descriptionHtml;
 
   return (
-    <ModuleDetails moduleData={moduleData}>
+    <ModuleDetails moduleData={moduleData} product={product}>
       <ProductForm />
     </ModuleDetails>
   );


### PR DESCRIPTION
This PR:
- Updates the product media gallery to source all product images from the Shopify Storefront API.
- Updates the product media gallery to source videos from both MongoDB (as it previously has) and the Shopify Storefront API. The videos, which are all embedded youtube videos, are de-duplicated so no video appears twice.
- Adds some optimization and better early exiting to the image cropping functionality to improve handling of many gallery images.