### PR TITLE
Fix missing screenWidth declaration

### DIFF
--- a/app/components/ModuleDetails.tsx
+++ b/app/components/ModuleDetails.tsx
@@ -46,6 +46,7 @@ export function ModuleDetails({
     }),
   );
 
+  const [screenWidth, setScreenWidth] = useState<number>(0);
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const handleResize = () => setScreenWidth(window.innerWidth);


### PR DESCRIPTION
This PR fixes the Chromagnon page by adding back the missing `screenWidth` declaration.